### PR TITLE
Removed GREFPlanes category in CfgTraders

### DIFF
--- a/Server/Exile.Tanoa/Exile.Tanoa/TRADERS/CfgTraders.hpp
+++ b/Server/Exile.Tanoa/Exile.Tanoa/TRADERS/CfgTraders.hpp
@@ -276,7 +276,7 @@
 			"MASPlanes",
 			//"SAFChoppers",
 			//"RHSPlanes",
-			"GREFPlanes",
+			//"GREFPlanes",
 			"CUAVs",
 			"A3UAVs",
 			"Pods"		


### PR DESCRIPTION
Removed the GREFPlanes category in CfgTraders to remove the space in the menu.